### PR TITLE
suppress pylance warning about reportUndefined Variable

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,13 @@
+{
+  // Keep strong linting in .py files
+  "python.analysis.diagnosticSeverityOverrides": {
+    "reportUndefinedVariable": "warning"
+  },
+
+  // Apply notebook-specific settings
+  "[jupyter]": {
+    "python.analysis.diagnosticSeverityOverrides": {
+      "reportUndefinedVariable": "none"
+    }
+  }
+}


### PR DESCRIPTION
when editing the jupyter notebooks in vscode (or on github codespaces), there are lots of pylance reports about reportUndefined Variable. This is a common problem with jupyter notebooks (because of the cell based structure), but it can be suppressed via vscode configuration. here is a fix


added settings.json to suppress pylance warning about reportUndefined Variable in jupyter notebooks only